### PR TITLE
Fixed string interval error

### DIFF
--- a/named.go
+++ b/named.go
@@ -223,12 +223,21 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 	names = make([]string, 0, 10)
 	rebound := make([]byte, 0, len(qs))
 
+	isstring := false
 	inName := false
 	last := len(qs) - 1
 	currentVar := 1
 	name := make([]byte, 0, 10)
 
 	for i, b := range qs {
+		//ignore if in string
+		if b == '\'' && qs[i-1] != '\\'{
+			isstring = !isstring
+		}
+		if isstring{
+			rebound = append(rebound, b)
+			continue
+		}
 		// a ':' while we're in a name is an error
 		if b == ':' {
 			// if this is the second ':' in a '::' escape sequence, append a ':'


### PR DESCRIPTION
While using sqlx's namedquery's i realized that the library believes that all instances of the colon are somehow are named variables, even if there inside a string. In my case with postgres, i had a interval notation as a string that was typed as '01:30:30' that cause the error "unexpected `:` while reading named param at [LOCATION]". I've been trying to fix the error most of the day, and my solution is having a bool flip while its reading a string to continue reading from it, with a sanity check to check if the comma is being escaped or not.

try running this code for example

var qs = `SELECT * FROM testtable WHERE timeposted BETWEEN (now() AT TIME ZONE 'utc') AND
(now() AT TIME ZONE 'utc') - interval '01:30:00') AND name = '\'this is a test\'' and id = :id`

previously, this would fail with said error, but now it works! I havent had a chance to add any unit test in, but you can use my scenario above in named_test.go
